### PR TITLE
Fix _security migration.

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ const monitorReplication = async function (status, ee) {
 // migrate the _security document from the source to the target
 const migrateAuth = async function (opts) {
   const securityDoc = '_security'
-
+  
   // establish the source account's username
   const parsed = new url.URL(opts.sourceURL)
   let username = null
@@ -130,7 +130,12 @@ const migrateAuth = async function (opts) {
   }
 
   data._id = securityDoc
-  await opts.tdb.insert(data)
+
+  opts.tdb.insert(data, securityDoc).then((res, err) => {
+    if (err) {
+      console.log(`Error inserting security object: ${JSON.stringify(err)}`)
+    }
+  })  
 }
 
 // migrate a single database from source ---> target


### PR DESCRIPTION
@glynnbird -- I find that the `.insert()` call in the nano npm, documented here: https://www.npmjs.com/package/nano#dbinsertdoc-params-callback doesn't work when you **just** pass it a document.  So yes, that would mean their statement:
> If params is a string, it's assumed it is the intended document _id. If params is an object, it's passed as query string parameters and docName is checked for defining the document _id:

Is not true. To be fair, I am using this with IBM Cloudant, which may have some implementation differences from vanilla CouchDB.

And that includes the `_security` document.  This PR changes couchreplicate to include use the **second** method signature where the ID (`_security`) is passed as well as the full document. 

I'm proposing this change because it made it such that couchreplicate would successfully migrate authorization data for me on an IBM Cloudant database... using it out of the box, it wouldn't.  I also added some error handling for when storing the security document failed.